### PR TITLE
FIX Fatal error: Unable to bridge NSNumber to Float

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,6 +15,7 @@ class _MyAppState extends State<MyApp> {
   YandexMapController _yandexMapController;
   Placemark _placemark = Placemark(
     point: _point,
+    opacity: 0.7,
     iconName: 'lib/assets/place.png',
     onTap: (latitude, longitude) => print('Tapped me at $latitude,$longitude')
   );

--- a/ios/Classes/YandexMapController.swift
+++ b/ios/Classes/YandexMapController.swift
@@ -163,7 +163,7 @@ public class YandexMapController: NSObject, FlutterPlatformView {
 
     placemark.addTapListener(with: mapObjectTapListener)
     placemark.userData = params["hashCode"] as! Int
-    placemark.opacity = params["opacity"] as! Float
+    placemark.opacity = (Float)(params["opacity"] as! Double)
     placemark.isDraggable = params["isDraggable"] as! Bool
 
     if (iconName != nil) {


### PR DESCRIPTION
Fatal error: Unable to bridge NSNumber to Float in method private func addPlacemarkToMap(_ params: [String: Any]), platform IOS.