### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ import YandexMapKit
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     YMKMapKit.setApiKey("YOUR_API_KEY")
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
+}
 ```
 
 ### Initializing for Android


### PR DESCRIPTION
Hi there, 
I was trying to quickstart with yandex_mapkit using the readme file and got into two issues: 

1) there is a missing closing bracket
2) error: 'UIApplicationLaunchOptionsKey' has been renamed to 'UIApplication.LaunchOptionsKey'