### PR TITLE
Fix #128

### DIFF
--- a/android/src/main/java/com/unact/yandexmapkit/YandexMapController.java
+++ b/android/src/main/java/com/unact/yandexmapkit/YandexMapController.java
@@ -701,8 +701,8 @@ public class YandexMapController implements PlatformView, MethodChannel.MethodCa
         result.success(null);
         break;
       case "isZoomGesturesEnabled":
-        boolean isZoomGesturesEnabled = isZoomGesturesEnabled();
-        result.success(isZoomGesturesEnabled);
+        boolean isZoomGesturesEnabledValue = isZoomGesturesEnabled();
+        result.success(isZoomGesturesEnabledValue);
         break;
       case "toggleZoomGestures":
         toggleZoomGestures(call);
@@ -733,8 +733,8 @@ public class YandexMapController implements PlatformView, MethodChannel.MethodCa
         result.success(userTargetPoint);
         break;
       case "isTiltGesturesEnabled":
-        boolean isTiltGesturesEnabled = isTiltGesturesEnabled();
-        result.success(isTiltGesturesEnabled);
+        boolean isTiltGesturesEnabledValue = isTiltGesturesEnabled();
+        result.success(isTiltGesturesEnabledValue);
         break;
       case "toggleTiltGestures":
         toggleTiltGestures(call);

--- a/ios/Classes/YandexMapController.swift
+++ b/ios/Classes/YandexMapController.swift
@@ -115,8 +115,8 @@ public class YandexMapController: NSObject, FlutterPlatformView {
       zoomOut()
       result(nil)
     case "isZoomGesturesEnabled":
-      let isZoomGesturesEnabled = isZoomGesturesEnabled()
-      result(isZoomGesturesEnabled)
+      let enabled = isZoomGesturesEnabled()
+      result(enabled)
     case "toggleZoomGestures":
       toggleZoomGestures(call)
       result(nil)
@@ -139,8 +139,8 @@ public class YandexMapController: NSObject, FlutterPlatformView {
       let userTargetPoint = getUserTargetPoint()
       result(userTargetPoint)
     case "isTiltGesturesEnabled":
-      let isTiltGesturesEnabled = isTiltGesturesEnabled()
-      result(isTiltGesturesEnabled)
+      let enabled = isTiltGesturesEnabled()
+      result(enabled)
     case "toggleTiltGestures":
       toggleTiltGestures(call)
       result(nil)


### PR DESCRIPTION
Фикс к [#128](https://github.com/Unact/yandex_mapkit/issues/128) - переименовал переменные, чтобы отличались от названий методов, так как в свифте при некоторых невыясненных обстоятельствах это может как работать, так и нет....