### PR TITLE
Search option point toJson fix

### DIFF
--- a/lib/src/types/search/search_options.dart
+++ b/lib/src/types/search/search_options.dart
@@ -37,7 +37,7 @@ class SearchOptions extends Equatable {
       'geometry': geometry,
       'disableSpellingCorrection': disableSpellingCorrection,
       'resultPageSize': resultPageSize,
-      'userPosition': userPosition,
+      'userPosition': userPosition?.toJson(),
       'origin': origin
     };
   }


### PR DESCRIPTION
SearchOptions toJson doesn't call userPosition's toJson method therefore invoking method channel with userPosition != null throws error, because you can only use default codecs to pass messages between Flutter and platform.
----
В SearchOptions в методе toJson у userPosition не вызывается его метод toJson, что приводит к ошибке в методах, содержащих в себе SearchOptions с userPosition != null, т.к. они используют method channel для общения с платформой, а platform channels поддерживают только базовые кодеки, не позволяющие создавать свои типы данных. 