### PR TITLE
[iOS] Проблема с кластером и зумом

### DIFF
--- a/ios/Classes/ClusterizedPlacemarkCollectionController.swift
+++ b/ios/Classes/ClusterizedPlacemarkCollectionController.swift
@@ -132,14 +132,14 @@ class ClusterizedPlacemarkCollectionController:
         return
       }
 
-      let params = result as! [String: Any]
-
-      self.clusters[cluster] = PlacemarkMapObjectController(
-        placemark: cluster.appearance,
-        params: params,
-        controller: self.controller!
-      )
-      cluster.addClusterTapListener(with: self)
+      if let params = result as? [String: Any] {
+        self.clusters[cluster] = PlacemarkMapObjectController(
+          placemark: cluster.appearance,
+          params: params,
+          controller: self.controller!
+        )
+        cluster.addClusterTapListener(with: self)
+      }
     }
   }
 


### PR DESCRIPTION
[RU] Если карта находится на виджете "слайд" и этот "слайд" уходит из поля видимости (свайп, jumpToPage(notSlideWithMap)), а также на карте есть большое кол-во кластеров и зум, то приложение на iOS крашилось, потому что кластеры не успевали правильно инциализироваться

[ENG] In case if app has slides as routing widgets (or whatever) and slide contain yandex_map_widget and map_widget contains a lot of clusters (in my case points count was more than 3000) and also map_widget is scrolling at same time as clusters initialising and user swiped page at this time user will get crash, because of clusters didn't initialise at all