### PR TITLE
Remove usage of deprecated constants in isM1Simulator method

### DIFF
--- a/ios/Classes/lite/YandexMapController.swift
+++ b/ios/Classes/lite/YandexMapController.swift
@@ -233,7 +233,11 @@ public class YandexMapController:
   }
 
   private static func isM1Simulator() -> Bool {
-    return (TARGET_IPHONE_SIMULATOR & TARGET_CPU_ARM64) != 0
+    #if arch(arm64) && os(iOS) && targetEnvironment(simulator)
+      return true
+    #else
+      return false
+    #endif
   }
 
   private func hasLocationPermission() -> Bool {


### PR DESCRIPTION
### Motivation

In the recent XCode update Flutter apps with `yandex_mapkit` package stopped launching because of an error in `isM1Simulator` method which used deprecated constant values.

This is the fix of `Swift Compiler Error (Xcode): Cannot find 'TARGET_IPHONE_SIMULATOR' in scope`.

### Changes

This PR replaces usages of deprecated constants by conditional compilation directives of Swift.

### Related issue

https://github.com/Unact/yandex_mapkit/issues/393