### PR TITLE
### Problem The plugin does not build on M1 (arm64) iOS simulators due to usage of the undefined `TARGET_IPHONE_SIMULATOR` macro in Swift code:

### DIFF
--- a/ios/Classes/lite/YandexMapController.swift
+++ b/ios/Classes/lite/YandexMapController.swift
@@ -233,7 +233,14 @@ public class YandexMapController:
   }
 
   private static func isM1Simulator() -> Bool {
-    return (TARGET_IPHONE_SIMULATOR & TARGET_CPU_ARM64) != 0
+      #if targetEnvironment(simulator)
+      if ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"]?.contains("arm64") == true {
+          return true
+      }
+      return false
+      #else
+      return false
+      #endif
   }
 
   private func hasLocationPermission() -> Bool {


### PR DESCRIPTION

### Solution
Replace the `TARGET_IPHONE_SIMULATOR` bitwise check with Swift’s compile-time `targetEnvironment(simulator)` and a runtime check for arm64 simulator using `SIMULATOR_MODEL_IDENTIFIER` environment variable.

### Testing
- Verified that the example app builds and runs successfully on an M1 Mac iOS simulator (e.g., iPhone 16 Plus).
- No regressions on other platforms expected as the check is guarded by compile-time flags.

Please consider merging this fix to improve compatibility with Apple Silicon simulators.
