### PR TITLE
fix: null-guard teardownChannels to avoid NPE on engine detach

### DIFF
--- a/android/src/main/java/com/unact/yandexmapkit/full/InitFull.java
+++ b/android/src/main/java/com/unact/yandexmapkit/full/InitFull.java
@@ -57,21 +57,30 @@ public class InitFull extends InitLite {
     pedestrianMethodChannel.setMethodCallHandler(yandexPedestrian);
   }
 
-  @SuppressWarnings({"ConstantConditions"})
   public void teardownChannels() {
-    searchMethodChannel.setMethodCallHandler(null);
-    searchMethodChannel = null;
+    if (searchMethodChannel != null) {
+      searchMethodChannel.setMethodCallHandler(null);
+      searchMethodChannel = null;
+    }
 
-    suggestMethodChannel.setMethodCallHandler(null);
-    suggestMethodChannel = null;
+    if (suggestMethodChannel != null) {
+      suggestMethodChannel.setMethodCallHandler(null);
+      suggestMethodChannel = null;
+    }
 
-    drivingMethodChannel.setMethodCallHandler(null);
-    drivingMethodChannel = null;
+    if (drivingMethodChannel != null) {
+      drivingMethodChannel.setMethodCallHandler(null);
+      drivingMethodChannel = null;
+    }
 
-    bicycleMethodChannel.setMethodCallHandler(null);
-    bicycleMethodChannel = null;
+    if (bicycleMethodChannel != null) {
+      bicycleMethodChannel.setMethodCallHandler(null);
+      bicycleMethodChannel = null;
+    }
 
-    pedestrianMethodChannel.setMethodCallHandler(null);
-    pedestrianMethodChannel = null;
+    if (pedestrianMethodChannel != null) {
+      pedestrianMethodChannel.setMethodCallHandler(null);
+      pedestrianMethodChannel = null;
+    }
   }
 }


### PR DESCRIPTION
## Summary

`InitFull.teardownChannels()` dereferences five `@Nullable MethodChannel` fields without null checks. The `@SuppressWarnings({\"ConstantConditions\"})` annotation hides the static analysis warning, but the runtime risk is real: if `FlutterActivity` is destroyed before `onAttachedToEngine` completes (or `onDetachedFromEngine` fires a second time), the fields are null and the first call (`searchMethodChannel.setMethodCallHandler(null)`) throws `NullPointerException`.

Firebase Crashlytics stack trace observed on Android 14 production device:

\`\`\`
Caused by java.lang.NullPointerException
  at com.unact.yandexmapkit.full.InitFull.teardownChannels (InitFull.java:62)
  at com.unact.yandexmapkit.full.InitFull.onDetachedFromEngine (InitFull.java:35)
  at io.flutter.embedding.engine.FlutterEngineConnectionRegistry.remove
  at io.flutter.embedding.engine.FlutterEngineConnectionRegistry.removeAll
  at io.flutter.embedding.engine.FlutterEngineConnectionRegistry.destroy
  at io.flutter.embedding.engine.FlutterEngine.destroy
  at io.flutter.embedding.android.FlutterActivityAndFragmentDelegate.onDetach
  at io.flutter.embedding.android.FlutterActivity.onDestroy
  at android.app.Activity.performDestroy
\`\`\`

This patch adds null guards around each channel teardown and removes the now-unnecessary `@SuppressWarnings` annotation. Behavior is unchanged for the normal lifecycle path.

## Test plan

- [x] Package builds cleanly (\`flutter pub get\` + \`flutter analyze\` in a consumer app)
- [x] Manual: rapid activity destroy mid-map-init no longer crashes
- [ ] Crashlytics: confirm the NPE stops appearing after a release with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)